### PR TITLE
Add Streamlit demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,16 @@ python src/knn_risk_classifier.py
 ```
 
 The script outputs basic evaluation metrics and a classification report for the model.
+
+## Streamlit App
+
+You can also explore the model interactively using [Streamlit](https://streamlit.io/).
+Launch the app with:
+
+```bash
+streamlit run src/streamlit_app.py
+```
+
+Use the sidebar to tweak dataset generation parameters and the number of
+neighbors used in the KNN classifier. The app displays the resulting metrics and
+classification report.

--- a/src/knn_risk_classifier.py
+++ b/src/knn_risk_classifier.py
@@ -60,8 +60,16 @@ def assign_risk(df):
     return df
 
 
-def train_knn(df):
-    """Train a KNN model and return evaluation metrics."""
+def train_knn(df, n_neighbors=3):
+    """Train a KNN model and return evaluation metrics.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Dataset with features and ``Risk Classification`` column.
+    n_neighbors : int, optional
+        Number of neighbours for ``KNeighborsClassifier``.
+    """
     X = df.drop(columns=["Risk Classification"])
     y = df["Risk Classification"]
 
@@ -70,7 +78,7 @@ def train_knn(df):
     X_train_scaled = scaler.fit_transform(X_train)
     X_test_scaled = scaler.transform(X_test)
 
-    knn = KNeighborsClassifier(n_neighbors=3)
+    knn = KNeighborsClassifier(n_neighbors=n_neighbors)
     knn.fit(X_train_scaled, y_train)
     y_pred = knn.predict(X_test_scaled)
 

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -1,0 +1,39 @@
+import streamlit as st
+from knn_risk_classifier import generate_dataset, assign_risk, train_knn
+
+
+def main():
+    st.title("Supplier Risk Classifier")
+
+    st.sidebar.header("Configuration")
+    sc_increase = st.sidebar.slider(
+        "SC Increase Percentage", min_value=1, max_value=10, value=4
+    )
+    qa_increase = st.sidebar.slider(
+        "QA Increase Percentage", min_value=1, max_value=10, value=1
+    )
+    n_samples = st.sidebar.number_input(
+        "Number of Samples", min_value=50, max_value=1000, value=350, step=50
+    )
+    n_neighbors = st.sidebar.number_input(
+        "KNN Neighbors", min_value=1, max_value=20, value=3, step=1
+    )
+
+    if st.sidebar.button("Run Classification"):
+        df = generate_dataset(
+            sc_increase_percentage=sc_increase,
+            qa_increase_percentage=qa_increase,
+            n_samples=int(n_samples),
+        )
+        df = assign_risk(df)
+        metrics, report = train_knn(df, n_neighbors=int(n_neighbors))
+
+        st.subheader("Metrics")
+        st.json(metrics)
+
+        st.subheader("Classification Report")
+        st.dataframe(report)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- make KNN neighbor count configurable
- add interactive Streamlit app
- document Streamlit usage in README

## Testing
- `python src/knn_risk_classifier.py | head -n 5`
- `python -m py_compile src/streamlit_app.py`
- `streamlit run src/streamlit_app.py --server.headless true --server.port 8501` *(fails to fetch IP)*

------
https://chatgpt.com/codex/tasks/task_e_6863cd229d90832b8345e0de5232f5e5